### PR TITLE
Enable Dependabot for npm dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    target-branch: develop
+    open-pull-requests-limit: 5
+    groups:
+      angular:
+        patterns:
+          - "@angular/*"
+          - "@angular-devkit/*"
+          - "@angular-eslint/*"
+        update-types:
+          - minor
+          - patch
+      npm-minor-patch:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "@angular/*"
+          - "@angular-devkit/*"
+          - "@angular-eslint/*"
+        update-types:
+          - minor
+          - patch
+    commit-message:
+      prefix: chore(deps)


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` for weekly npm dependency scans at the repo root.
- Opens PRs against `develop` to match THFF branch flow.
- Groups `@angular/*`, `@angular-devkit/*`, and `@angular-eslint/*` updates together so Angular stays in sync.
- Groups remaining minor/patch updates separately; major bumps still arrive individually.

## Notes
GitHub reads Dependabot config from the **default branch** (`master`). Dependabot will not run until this file is promoted through `develop` → `staging` → `master`.

## Test plan
- [ ] Merge to `develop`, then promote to `master`
- [ ] Confirm Dependabot appears under repo **Insights → Dependency graph → Dependabot**
- [ ] Verify first scheduled PR targets `develop` on the next Monday run

Made with [Cursor](https://cursor.com)