### PR TITLE
fix(home): show grant cycle status for logged-out visitors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thff-fuse2",
-  "version": "5.1.7",
+  "version": "5.1.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "thff-fuse2",
-      "version": "5.1.7",
+      "version": "5.1.8",
       "hasInstallScript": true,
       "license": "https://themeforest.net/licenses/standard",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thff-fuse2",
-  "version": "5.1.7",
+  "version": "5.1.8",
   "description": "THFF FE built with Fuse - Angular Admin Template and Starter Project",
   "author": "lcborn4@gmail.com",
   "license": "https://themeforest.net/licenses/standard",

--- a/src/app/core/auth/auth.interceptor.ts
+++ b/src/app/core/auth/auth.interceptor.ts
@@ -3,7 +3,6 @@ import { HttpErrorResponse, HttpEvent, HttpHandler, HttpInterceptor, HttpRequest
 import { BehaviorSubject, catchError, filter, Observable, switchMap, take, throwError } from 'rxjs';
 import { Router } from '@angular/router';
 import { AuthService } from 'app/core/auth/auth.service';
-import { AuthUtils } from 'app/core/auth/auth.utils';
 
 @Injectable()
 export class AuthInterceptor implements HttpInterceptor {
@@ -17,8 +16,8 @@ export class AuthInterceptor implements HttpInterceptor {
         req: HttpRequest<any>,
         next: HttpHandler
     ): Observable<HttpEvent<any>> {
-        // Attach token if available (even if expired — backend refresh endpoint needs it)
-        let newReq = this._addToken(req);
+        // Public endpoints must work without a session (e.g. home page grant-cycle status).
+        const newReq = this._isPublicEndpoint(req.url) ? req : this._addToken(req);
 
         // Response
         return next.handle(newReq).pipe(
@@ -34,13 +33,7 @@ export class AuthInterceptor implements HttpInterceptor {
                         req.url.includes(endpoint)
                     );
 
-                    // Don't intercept public endpoints
-                    const publicEndpoints = ['/submission-year', '/health'];
-                    const isPublicEndpoint = publicEndpoints.some(endpoint =>
-                        req.url.includes(endpoint)
-                    );
-
-                    if (isSkipEndpoint || isPublicEndpoint) {
+                    if (isSkipEndpoint || this._isPublicEndpoint(req.url)) {
                         return throwError(() => error);
                     }
 
@@ -51,6 +44,12 @@ export class AuthInterceptor implements HttpInterceptor {
                 return throwError(() => error);
             })
         );
+    }
+
+    /** Endpoints that must not require auth (landing page grant-cycle status, health checks). */
+    private _isPublicEndpoint(url: string): boolean {
+        const publicEndpoints = ['/submission-year', '/health'];
+        return publicEndpoints.some((endpoint) => url.includes(endpoint));
     }
 
     /**

--- a/src/app/modules/landing/home/home.component.html
+++ b/src/app/modules/landing/home/home.component.html
@@ -12,11 +12,11 @@
             environment, religion, and social services.
         </p>
 
+        <p class="text-sm text-gray-500" *ngIf="loading">Loading grant cycle status…</p>
+
         <p class="text-lg text-gray-700" *ngIf="!loading && latestSubmissionYear">
             The {{ latestSubmissionYear.year }} grant cycle is
-            <span class="font-semibold" [ngClass]="portalOpen ? 'text-green-600' : 'text-red-600'">
-                {{ portalOpen ? 'open' : 'closed' }}
-            </span>.
+            <span class="font-semibold" [ngClass]="portalOpen ? 'text-green-600' : 'text-red-600'">{{ portalOpen ? 'open' : 'closed' }}</span>.
         </p>
     </div>
 

--- a/src/app/modules/landing/home/home.component.ts
+++ b/src/app/modules/landing/home/home.component.ts
@@ -1,8 +1,10 @@
-import { Component, OnInit, ViewEncapsulation } from '@angular/core';
-import { Router } from '@angular/router';
-import { AuthService } from 'app/core/auth/auth.service';
-import { AuthUtils } from 'app/core/auth/auth.utils';
+import { ChangeDetectorRef, Component, OnDestroy, OnInit, ViewEncapsulation } from '@angular/core';
+import { of } from 'rxjs';
+import { catchError, finalize, take, timeout } from 'rxjs/operators';
 import { SubmissionYearsService } from 'app/core/services/admin/submission-years.service';
+
+/** Max wait for the public submission-year call on the landing page. */
+const API_WAIT_MS = 12000;
 
 @Component({
     standalone: false,
@@ -10,18 +12,16 @@ import { SubmissionYearsService } from 'app/core/services/admin/submission-years
     templateUrl: './home.component.html',
     encapsulation: ViewEncapsulation.None
 })
-export class LandingHomeComponent implements OnInit {
+export class LandingHomeComponent implements OnInit, OnDestroy {
     latestSubmissionYear: any;
     portalOpen: boolean = false;
     loading: boolean = true;
 
-    /**
-     * Constructor
-     */
+    private _destroyed = false;
+
     constructor(
-        private _router: Router, 
-        private _authService: AuthService,
-        private _submissionYearsService: SubmissionYearsService
+        private _submissionYearsService: SubmissionYearsService,
+        private _cdr: ChangeDetectorRef,
     ) {
     }
 
@@ -29,24 +29,32 @@ export class LandingHomeComponent implements OnInit {
         this.getLatestSubmissionYear();
     }
 
+    ngOnDestroy(): void {
+        this._destroyed = true;
+    }
+
     getLatestSubmissionYear(): void {
         this.loading = true;
-        this._submissionYearsService.getLatestSubmissionYear()
-            .subscribe({
-                next: (year) => {
-                    this.latestSubmissionYear = year;
-                    if (year) {
-                        this.portalOpen = year.active;
+
+        this._submissionYearsService
+            .getLatestSubmissionYear()
+            .pipe(
+                take(1),
+                timeout({ first: API_WAIT_MS }),
+                catchError((err) => {
+                    console.error('Home: getLatestSubmissionYear failed', err);
+                    return of(null);
+                }),
+                finalize(() => {
+                    if (!this._destroyed) {
+                        this.loading = false;
+                        this._cdr.detectChanges();
                     }
-                    this.loading = false;
-                },
-                error: (err) => {
-                    this.loading = false;
-                    // Don't let errors propagate to avoid triggering reload loops
-                    // Set default values if API call fails
-                    this.latestSubmissionYear = null;
-                    this.portalOpen = false;
-                }
+                })
+            )
+            .subscribe((year) => {
+                this.latestSubmissionYear = year;
+                this.portalOpen = !!year?.active;
             });
     }
 }


### PR DESCRIPTION
Load portal open/closed on the landing page via the public submission-year API without attaching auth headers. Bump patch version to 5.1.8.