### PR TITLE
chore: bump version to 5.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thff-fuse2",
-  "version": "5.6.0",
+  "version": "5.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "thff-fuse2",
-      "version": "5.6.0",
+      "version": "5.6.1",
       "hasInstallScript": true,
       "license": "https://themeforest.net/licenses/standard",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thff-fuse2",
-  "version": "5.6.0",
+  "version": "5.6.1",
   "description": "THFF FE built with Fuse - Angular Admin Template and Starter Project",
   "author": "lcborn4@gmail.com",
   "license": "https://themeforest.net/licenses/standard",


### PR DESCRIPTION
## Summary
- Bump app version to **5.6.1** for the Angular security patch release

## Test plan
- [ ] Footer/version display shows `5.6.1`


Made with [Cursor](https://cursor.com)