### PR TITLE
fix(501c3): align upload dialog busy state

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thff-fuse2",
-  "version": "5.6.1",
+  "version": "5.6.2",
   "description": "THFF FE built with Fuse - Angular Admin Template and Starter Project",
   "author": "lcborn4@gmail.com",
   "license": "https://themeforest.net/licenses/standard",

--- a/src/app/modules/pages/organization/org-doc501c3/upload-501c3-dialog/upload-501c3-dialog.component.html
+++ b/src/app/modules/pages/organization/org-doc501c3/upload-501c3-dialog/upload-501c3-dialog.component.html
@@ -25,14 +25,17 @@
         </label>
     </mat-dialog-content>
 
-    <mat-dialog-actions class="flex justify-end gap-2 pt-2">
+    <mat-dialog-actions class="flex items-center justify-end gap-2 pt-2">
         <button mat-button (click)="onCancel()" [disabled]="uploading">Cancel</button>
         <button mat-flat-button color="primary"
-                [disabled]="!file || uploading"
+                class="min-w-[140px]"
+                [disabled]="!file"
                 (click)="onUpload()">
-            <mat-spinner *ngIf="uploading" [diameter]="20" class="mr-2"></mat-spinner>
-            <mat-icon *ngIf="!uploading" class="mr-2 icon-size-5">upload</mat-icon>
-            <span>{{ uploading ? 'Uploading...' : 'Upload' }}</span>
+            <span class="flex items-center justify-center leading-none">
+                <mat-spinner *ngIf="uploading" [diameter]="18" class="thff-btn-spinner mr-2"></mat-spinner>
+                <mat-icon *ngIf="!uploading" class="mr-2 icon-size-5">upload</mat-icon>
+                <span>{{ uploading ? 'Uploading...' : 'Upload' }}</span>
+            </span>
         </button>
     </mat-dialog-actions>
 </div>

--- a/src/app/modules/pages/organization/org-doc501c3/upload-501c3-dialog/upload-501c3-dialog.component.html
+++ b/src/app/modules/pages/organization/org-doc501c3/upload-501c3-dialog/upload-501c3-dialog.component.html
@@ -31,10 +31,10 @@
                 class="min-w-[140px]"
                 [disabled]="!file"
                 (click)="onUpload()">
-            <span class="flex items-center justify-center leading-none">
-                <mat-spinner *ngIf="uploading" [diameter]="18" class="thff-btn-spinner mr-2"></mat-spinner>
+            <span class="inline-flex items-center justify-center">
+                <mat-spinner *ngIf="uploading" [diameter]="18" class="thff-btn-spinner mr-2 flex-shrink-0"></mat-spinner>
                 <mat-icon *ngIf="!uploading" class="mr-2 icon-size-5">upload</mat-icon>
-                <span>{{ uploading ? 'Uploading...' : 'Upload' }}</span>
+                <span class="leading-none">{{ uploading ? 'Uploading...' : 'Upload' }}</span>
             </span>
         </button>
     </mat-dialog-actions>

--- a/src/app/modules/pages/organization/org-doc501c3/upload-501c3-dialog/upload-501c3-dialog.component.ts
+++ b/src/app/modules/pages/organization/org-doc501c3/upload-501c3-dialog/upload-501c3-dialog.component.ts
@@ -11,6 +11,11 @@ export interface Upload501c3DialogData {
     standalone: false,
     selector: 'app-upload-501c3-dialog',
     templateUrl: './upload-501c3-dialog.component.html',
+    styles: [`
+        :host ::ng-deep .thff-btn-spinner circle {
+            stroke: currentColor;
+        }
+    `],
 })
 export class Upload501c3DialogComponent {
     file: File = null;
@@ -37,7 +42,7 @@ export class Upload501c3DialogComponent {
     }
 
     onUpload(): void {
-        if (!this.file) { return; }
+        if (!this.file || this.uploading) { return; }
 
         this.uploading = true;
         this.upload501c3Service.upload501c3(this.file, this.data.orgID).subscribe({


### PR DESCRIPTION
Fixes the misaligned "Uploading..." state in the 501(c)(3) upload dialog.

## Changes
- Keep the Upload button filled (teal) while uploading instead of graying out to the disabled state.
- Center the spinner + "Uploading..." label so it no longer drops below/right of the Cancel button.
- White spinner (stroke: currentColor) so it's visible on the teal button.
- Fixed min-width so the button doesn't resize when the label changes.
- Guard onUpload() against double submits (since the button is no longer disabled during upload).

## Test plan
- [ ] Open org 501(c)(3) card then Upload dialog
- [ ] Select a file and click Upload
- [ ] Spinner + "Uploading..." stays aligned with Cancel, button stays teal

Made with [Cursor](https://cursor.com)