### PR TITLE
fix(501c3): plain progress indicator while uploading (v5.6.3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thff-fuse2",
-  "version": "5.6.2",
+  "version": "5.6.3",
   "description": "THFF FE built with Fuse - Angular Admin Template and Starter Project",
   "author": "lcborn4@gmail.com",
   "license": "https://themeforest.net/licenses/standard",

--- a/src/app/modules/pages/organization/org-doc501c3/upload-501c3-dialog/upload-501c3-dialog.component.html
+++ b/src/app/modules/pages/organization/org-doc501c3/upload-501c3-dialog/upload-501c3-dialog.component.html
@@ -26,16 +26,23 @@
     </mat-dialog-content>
 
     <mat-dialog-actions class="flex items-center justify-end gap-2 pt-2">
-        <button mat-button (click)="onCancel()" [disabled]="uploading">Cancel</button>
-        <button mat-flat-button color="primary"
-                class="min-w-[140px]"
-                [disabled]="!file"
-                (click)="onUpload()">
-            <span class="inline-flex items-center justify-center">
-                <mat-spinner *ngIf="uploading" [diameter]="18" class="thff-btn-spinner mr-2 flex-shrink-0"></mat-spinner>
-                <mat-icon *ngIf="!uploading" class="mr-2 icon-size-5">upload</mat-icon>
-                <span class="leading-none">{{ uploading ? 'Uploading...' : 'Upload' }}</span>
-            </span>
-        </button>
+        <!-- Uploading: plain progress indicator, not a button -->
+        <div *ngIf="uploading" class="inline-flex items-center px-2 text-sm font-medium text-gray-500">
+            <mat-spinner [diameter]="18" class="mr-2 flex-shrink-0"></mat-spinner>
+            <span>Uploading...</span>
+        </div>
+
+        <!-- Idle: actions -->
+        <ng-container *ngIf="!uploading">
+            <button mat-button (click)="onCancel()">Cancel</button>
+            <button mat-flat-button color="primary"
+                    [disabled]="!file"
+                    (click)="onUpload()">
+                <span class="inline-flex items-center justify-center">
+                    <mat-icon class="mr-2 icon-size-5">upload</mat-icon>
+                    <span>Upload</span>
+                </span>
+            </button>
+        </ng-container>
     </mat-dialog-actions>
 </div>

--- a/src/app/modules/pages/organization/org-doc501c3/upload-501c3-dialog/upload-501c3-dialog.component.ts
+++ b/src/app/modules/pages/organization/org-doc501c3/upload-501c3-dialog/upload-501c3-dialog.component.ts
@@ -11,11 +11,6 @@ export interface Upload501c3DialogData {
     standalone: false,
     selector: 'app-upload-501c3-dialog',
     templateUrl: './upload-501c3-dialog.component.html',
-    styles: [`
-        :host ::ng-deep .thff-btn-spinner circle {
-            stroke: currentColor;
-        }
-    `],
 })
 export class Upload501c3DialogComponent {
     file: File = null;


### PR DESCRIPTION
Replaces the teal "Uploading..." button with a plain inline spinner + text during upload, so the busy state no longer looks like a clickable button. Cancel/Upload only render when idle.

Version bumped to 5.6.3.

Made with [Cursor](https://cursor.com)