### PR TITLE
Release: proposal submit clarity (v5.6.4) to production

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thff-fuse2",
-  "version": "5.6.3",
+  "version": "5.6.4",
   "description": "THFF FE built with Fuse - Angular Admin Template and Starter Project",
   "author": "lcborn4@gmail.com",
   "license": "https://themeforest.net/licenses/standard",

--- a/src/app/modules/pages/proposal/create-proposal/create-proposal.component.html
+++ b/src/app/modules/pages/proposal/create-proposal/create-proposal.component.html
@@ -38,8 +38,9 @@
             </h1>
             <p class="mt-1 max-w-3xl text-sm text-gray-500 dark:text-gray-400">
                 Your answers are saved as a draft automatically while you work, so you can leave and come back without
-                losing progress. When you create the proposal, it is submitted automatically and considered for grant
-                funding for that cycle. You can return and update your proposal anytime until the portal closes.
+                losing progress. When you're finished, click <span class="font-semibold">Submit Application</span> at
+                the bottom to send it in for grant consideration for that cycle. You can return and update your
+                application anytime until the portal closes.
             </p>
         </div>
     </div>
@@ -333,42 +334,52 @@
                         <ng-container *ngIf="!redirectingAfterSubmit">
                             <div class="text-sm text-secondary max-w-md">
                                 <p class="m-0 mb-2 text-gray-600 dark:text-gray-300">
-                                    Creating this proposal submits it for grant consideration. There is no separate
-                                    submit step after creation. You may update it until the portal closes.
+                                    Clicking <span class="font-semibold">Submit Application</span> sends your
+                                    application in for grant consideration. There is no separate submit step — you may
+                                    keep updating it until the portal closes.
                                 </p>
-                                Need help creating your proposal?
+                                Need help with your application?
                                 <a class="thff-link" href="mailto:support@hagenfamilyfoundation.org">
                                     Contact support
                                 </a>.
                             </div>
-                            <div class="flex items-center gap-3">
-                                <button
-                                    mat-stroked-button
-                                    type="button"
-                                    [disabled]="submittingProposal"
-                                    (click)="cancel()"
+                            <div class="flex flex-col items-stretch sm:items-end gap-2">
+                                <div class="flex items-center gap-3">
+                                    <button
+                                        mat-stroked-button
+                                        type="button"
+                                        [disabled]="submittingProposal"
+                                        (click)="cancel()"
+                                    >
+                                        Cancel
+                                    </button>
+                                    <button
+                                        mat-raised-button
+                                        [color]="'primary'"
+                                        type="button"
+                                        class="create-proposal-submit"
+                                        [disabled]="!groupedForm.valid || submittingProposal"
+                                        [attr.aria-busy]="submittingProposal"
+                                        (click)="createProposal()"
+                                    >
+                                        <span class="create-proposal-submit__content">
+                                            <mat-progress-spinner
+                                                *ngIf="submittingProposal"
+                                                class="create-proposal-submit__spinner"
+                                                diameter="20"
+                                                mode="indeterminate"
+                                            />
+                                            <span>{{ submittingProposal ? 'Submitting…' : 'Submit Application' }}</span>
+                                        </span>
+                                    </button>
+                                </div>
+                                <p
+                                    *ngIf="!groupedForm.valid && !submittingProposal"
+                                    class="m-0 text-xs text-amber-700 dark:text-amber-500 sm:text-right"
+                                    role="status"
                                 >
-                                    Cancel
-                                </button>
-                                <button
-                                    mat-raised-button
-                                    [color]="'primary'"
-                                    type="button"
-                                    class="create-proposal-submit"
-                                    [disabled]="!groupedForm.valid || submittingProposal"
-                                    [attr.aria-busy]="submittingProposal"
-                                    (click)="createProposal()"
-                                >
-                                    <span class="create-proposal-submit__content">
-                                        <mat-progress-spinner
-                                            *ngIf="submittingProposal"
-                                            class="create-proposal-submit__spinner"
-                                            diameter="20"
-                                            mode="indeterminate"
-                                        />
-                                        <span>{{ submittingProposal ? 'Submitting…' : 'Create Proposal' }}</span>
-                                    </span>
-                                </button>
+                                    Complete these fields to submit: {{ missingFieldLabels.join(', ') }}
+                                </p>
                             </div>
                         </ng-container>
                         <div

--- a/src/app/modules/pages/proposal/create-proposal/create-proposal.component.html
+++ b/src/app/modules/pages/proposal/create-proposal/create-proposal.component.html
@@ -38,9 +38,9 @@
             </h1>
             <p class="mt-1 max-w-3xl text-sm text-gray-500 dark:text-gray-400">
                 Your answers are saved as a draft automatically while you work, so you can leave and come back without
-                losing progress. When you're finished, click <span class="font-semibold">Submit Application</span> at
-                the bottom to send it in for grant consideration for that cycle. You can return and update your
-                application anytime until the portal closes.
+                losing progress. When you're finished, click <span class="font-semibold">Create Proposal</span> at the
+                bottom — this submits it for grant consideration for that cycle (there is no separate submit step). You
+                can return and update your proposal anytime until the portal closes.
             </p>
         </div>
     </div>
@@ -333,12 +333,15 @@
                     <div class="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3 pt-4 border-t">
                         <ng-container *ngIf="!redirectingAfterSubmit">
                             <div class="text-sm text-secondary max-w-md">
-                                <p class="m-0 mb-2 text-gray-600 dark:text-gray-300">
-                                    Clicking <span class="font-semibold">Submit Application</span> sends your
-                                    application in for grant consideration. There is no separate submit step — you may
-                                    keep updating it until the portal closes.
-                                </p>
-                                Need help with your application?
+                                <div class="mb-2 flex items-start gap-2 rounded-lg bg-blue-50 dark:bg-blue-900/20 px-3 py-2 text-blue-800 dark:text-blue-200">
+                                    <mat-icon class="icon-size-5 mt-0.5 flex-shrink-0">info</mat-icon>
+                                    <p class="m-0">
+                                        Clicking <span class="font-semibold">Create Proposal</span> submits your
+                                        proposal for grant consideration — there is no separate submit step. You can
+                                        keep updating it until the portal closes.
+                                    </p>
+                                </div>
+                                Need help with your proposal?
                                 <a class="thff-link" href="mailto:support@hagenfamilyfoundation.org">
                                     Contact support
                                 </a>.
@@ -369,7 +372,7 @@
                                                 diameter="20"
                                                 mode="indeterminate"
                                             />
-                                            <span>{{ submittingProposal ? 'Submitting…' : 'Submit Application' }}</span>
+                                            <span>{{ submittingProposal ? 'Submitting…' : 'Create Proposal' }}</span>
                                         </span>
                                     </button>
                                 </div>
@@ -378,7 +381,7 @@
                                     class="m-0 text-xs text-amber-700 dark:text-amber-500 sm:text-right"
                                     role="status"
                                 >
-                                    Complete these fields to submit: {{ missingFieldLabels.join(', ') }}
+                                    Complete these fields to create your proposal: {{ missingFieldLabels.join(', ') }}
                                 </p>
                             </div>
                         </ng-container>

--- a/src/app/modules/pages/proposal/create-proposal/create-proposal.component.ts
+++ b/src/app/modules/pages/proposal/create-proposal/create-proposal.component.ts
@@ -285,6 +285,25 @@ export class CreateProposalComponent implements OnInit, OnDestroy {
             .filter(key => this.groupedForm.get(key).valid).length;
     }
 
+    readonly fieldLabels: Record<string, string> = {
+        projectTitle: 'Project Title',
+        purpose: 'Purpose',
+        goals: 'Goals',
+        narrative: 'Narrative',
+        timeTable: 'Time Table',
+        amountRequested: 'Amount Requested',
+        itemizedBudget: 'Itemized Budget',
+        totalProjectCost: 'Total Project Cost',
+    };
+
+    /** Labels of the fields still keeping the form from being submittable. */
+    get missingFieldLabels(): string[] {
+        if (!this.groupedForm) { return []; }
+        return Object.keys(this.groupedForm.controls)
+            .filter(key => this.groupedForm.get(key)?.invalid)
+            .map(key => this.fieldLabels[key] ?? key);
+    }
+
     private get draftKey(): string {
         return proposalDraftStorageKey(this.org);
     }


### PR DESCRIPTION
Promotes v5.6.4 to production (THFF-135): clarifies that "Create Proposal" submits the proposal (info callout + header copy + disabled-state hint listing incomplete fields).

Prod deploy now runs on the scoped thff-user CI key.

Made with [Cursor](https://cursor.com)