### PR TITLE
Promote develop → staging: meeting live sync (Socket.IO)

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -38,7 +38,9 @@
               "highlight.js",
               "crypto-js/enc-utf8",
               "crypto-js/hmac-sha256",
-              "crypto-js/enc-base64"
+              "crypto-js/enc-base64",
+              "debug",
+              "socket.io-client"
             ],
             "assets": [
               "src/favicon-16x16.png",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thff-fuse2",
-  "version": "5.6.1",
+  "version": "5.6.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "thff-fuse2",
-      "version": "5.6.1",
+      "version": "5.6.4",
       "hasInstallScript": true,
       "license": "https://themeforest.net/licenses/standard",
       "dependencies": {
@@ -39,6 +39,7 @@
         "perfect-scrollbar": "1.5.3",
         "quill": "^2.0.3",
         "rxjs": "7.5.1",
+        "socket.io-client": "^4.8.3",
         "tslib": "2.3.1",
         "typescript": "5.9.3",
         "zone.js": "0.15.1"
@@ -7592,7 +7593,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
       "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@standard-schema/spec": {
@@ -10576,11 +10576,44 @@
         "node": ">=10.2.0"
       }
     },
+    "node_modules/engine.io-client": {
+      "version": "6.6.6",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.6.tgz",
+      "integrity": "sha512-iY6QdftLQ9pyiPoX082bpf/u1UewnOaJrtJIF9T0++QB34lZrj0uP+Q/bj8AlUsAxqhnkTV2BS8SBZSxOmoV5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.21.0",
+        "xmlhttprequest-ssl": "~2.1.1"
+      }
+    },
+    "node_modules/engine.io-client/node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/engine.io-parser": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
       "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -17330,11 +17363,25 @@
         "ws": "~8.18.3"
       }
     },
+    "node_modules/socket.io-client": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
+      "integrity": "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-client": "~6.6.1",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/socket.io-parser": {
       "version": "4.2.6",
       "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
       "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
@@ -19513,6 +19560,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/y18n": {
@@ -23937,8 +23992,7 @@
     "@socket.io/component-emitter": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
-      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
-      "dev": true
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA=="
     },
     "@standard-schema/spec": {
       "version": "1.1.0",
@@ -25981,11 +26035,29 @@
         "ws": "~8.18.3"
       }
     },
+    "engine.io-client": {
+      "version": "6.6.6",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.6.tgz",
+      "integrity": "sha512-iY6QdftLQ9pyiPoX082bpf/u1UewnOaJrtJIF9T0++QB34lZrj0uP+Q/bj8AlUsAxqhnkTV2BS8SBZSxOmoV5Q==",
+      "requires": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.21.0",
+        "xmlhttprequest-ssl": "~2.1.1"
+      },
+      "dependencies": {
+        "ws": {
+          "version": "8.21.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+          "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="
+        }
+      }
+    },
     "engine.io-parser": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
-      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
-      "dev": true
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q=="
     },
     "enhanced-resolve": {
       "version": "5.20.1",
@@ -30379,11 +30451,21 @@
         "ws": "~8.18.3"
       }
     },
+    "socket.io-client": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
+      "integrity": "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==",
+      "requires": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-client": "~6.6.1",
+        "socket.io-parser": "~4.2.4"
+      }
+    },
     "socket.io-parser": {
       "version": "4.2.6",
       "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
       "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
-      "dev": true,
       "requires": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.4.1"
@@ -31677,6 +31759,11 @@
         "is-wsl": "^3.1.0",
         "powershell-utils": "^0.1.0"
       }
+    },
+    "xmlhttprequest-ssl": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ=="
     },
     "y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "perfect-scrollbar": "1.5.3",
     "quill": "^2.0.3",
     "rxjs": "7.5.1",
+    "socket.io-client": "^4.8.3",
     "tslib": "2.3.1",
     "typescript": "5.9.3",
     "zone.js": "0.15.1"

--- a/src/app/core/services/admin/meeting-realtime.service.ts
+++ b/src/app/core/services/admin/meeting-realtime.service.ts
@@ -1,0 +1,101 @@
+import { Injectable, NgZone } from '@angular/core';
+import { BehaviorSubject, Observable, Subject } from 'rxjs';
+import { io, Socket } from 'socket.io-client';
+import { environment } from '../../../../environments/environment';
+
+/**
+ * Thin Socket.IO wrapper for live meeting updates. A single shared connection is
+ * lazily created on first use, authenticated with the stored access token, and
+ * used to join/leave per-meeting rooms. Emits populated meeting payloads pushed
+ * by the backend after any mutation.
+ */
+@Injectable({ providedIn: 'root' })
+export class MeetingRealtimeService {
+    private socket: Socket | null = null;
+    private joinedMeetingId: string | null = null;
+
+    private readonly meetingUpdates$ = new Subject<any>();
+    private readonly connected$ = new BehaviorSubject<boolean>(false);
+
+    constructor(private zone: NgZone) {}
+
+    private ensureSocket(): Socket {
+        if (this.socket) {
+            return this.socket;
+        }
+
+        const token = localStorage.getItem('accessToken') ?? '';
+        // Empty socketUrl => connect to same origin (dev proxy forwards /socket.io).
+        const url = environment.socketUrl || undefined;
+
+        this.socket = io(url as string, {
+            auth: { token },
+            // WebSocket-only to match the server (no sticky sessions needed).
+            transports: ['websocket'],
+            reconnection: true,
+            reconnectionDelay: 1000,
+            reconnectionDelayMax: 8000,
+        });
+
+        this.socket.on('connect', () =>
+            this.zone.run(() => {
+                this.connected$.next(true);
+                // Re-join the active room after (re)connect.
+                if (this.joinedMeetingId) {
+                    this.socket?.emit('meeting:join', this.joinedMeetingId);
+                }
+            })
+        );
+
+        this.socket.on('disconnect', () =>
+            this.zone.run(() => this.connected$.next(false))
+        );
+
+        this.socket.on('connect_error', () =>
+            this.zone.run(() => this.connected$.next(false))
+        );
+
+        this.socket.on('meeting:updated', (meeting: any) =>
+            this.zone.run(() => this.meetingUpdates$.next(meeting))
+        );
+
+        return this.socket;
+    }
+
+    /** Stream of populated meeting payloads for the currently joined room. */
+    meetingUpdates(): Observable<any> {
+        return this.meetingUpdates$.asObservable();
+    }
+
+    /** Live connection state (true once the socket handshake succeeds). */
+    connected(): Observable<boolean> {
+        return this.connected$.asObservable();
+    }
+
+    get isConnected(): boolean {
+        return this.connected$.value;
+    }
+
+    joinMeeting(meetingId: string): void {
+        if (!meetingId) {
+            return;
+        }
+        const socket = this.ensureSocket();
+        if (this.joinedMeetingId && this.joinedMeetingId !== meetingId) {
+            socket.emit('meeting:leave', this.joinedMeetingId);
+        }
+        this.joinedMeetingId = meetingId;
+        if (socket.connected) {
+            socket.emit('meeting:join', meetingId);
+        }
+    }
+
+    leaveMeeting(meetingId: string): void {
+        if (this.socket && meetingId) {
+            this.socket.emit('meeting:leave', meetingId);
+        }
+        if (this.joinedMeetingId === meetingId) {
+            this.joinedMeetingId = null;
+        }
+    }
+}

--- a/src/app/modules/pages/director/meeting-detail/meeting-detail.component.html
+++ b/src/app/modules/pages/director/meeting-detail/meeting-detail.component.html
@@ -17,6 +17,13 @@
                           [ngClass]="getStatusColor(meeting.status)">
                         {{ getStatusLabel(meeting.status) }}
                     </span>
+                    <span *ngIf="showLiveIndicator"
+                          class="inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-700 dark:bg-red-900 dark:bg-opacity-40 dark:text-red-300"
+                          [matTooltip]="liveUpdatedAt ? ('Updated ' + (liveUpdatedAt | date:'h:mm:ss a')) : 'Updates automatically'"
+                          aria-label="Live meeting — updates automatically">
+                        <span class="meeting-live-dot"></span>
+                        Live
+                    </span>
                 </div>
                 <div class="flex flex-wrap items-center gap-2">
                     <a *ngIf="meeting.status === 'completed' && hasFundedProposals()"

--- a/src/app/modules/pages/director/meeting-detail/meeting-detail.component.scss
+++ b/src/app/modules/pages/director/meeting-detail/meeting-detail.component.scss
@@ -2,6 +2,32 @@
     display: block;
 }
 
+.meeting-live-dot {
+    width: 0.5rem;
+    height: 0.5rem;
+    border-radius: 9999px;
+    background-color: currentColor;
+    animation: meeting-live-pulse 1.6s ease-in-out infinite;
+}
+
+@keyframes meeting-live-pulse {
+    0%,
+    100% {
+        opacity: 1;
+        transform: scale(1);
+    }
+    50% {
+        opacity: 0.35;
+        transform: scale(0.7);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .meeting-live-dot {
+        animation: none;
+    }
+}
+
 :host ::ng-deep .mat-row {
     transition: background-color 150ms ease;
 

--- a/src/app/modules/pages/director/meeting-detail/meeting-detail.component.ts
+++ b/src/app/modules/pages/director/meeting-detail/meeting-detail.component.ts
@@ -16,9 +16,10 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatDialog } from '@angular/material/dialog';
 import { Sort } from '@angular/material/sort';
 import { PageEvent } from '@angular/material/paginator';
-import { Subject, EMPTY, forkJoin, of, from } from 'rxjs';
+import { Subject, EMPTY, forkJoin, of, from, interval } from 'rxjs';
 import { catchError, debounceTime, filter, finalize, last, map, mergeMap, switchMap, take, tap } from 'rxjs/operators';
 import { MeetingService } from 'app/core/services/admin/meeting.service';
+import { MeetingRealtimeService } from 'app/core/services/admin/meeting-realtime.service';
 import { AuthService } from 'app/core/auth/auth.service';
 import { UserPreferencesService } from 'app/core/services/user/user-preferences.service';
 import { meetingStatusLabel } from '../meeting-status.labels';
@@ -129,6 +130,15 @@ export class MeetingDetailComponent implements OnInit, AfterViewInit {
 
     private static readonly BULK_ALLOCATION_CONCURRENCY = 8;
 
+    /** How often to poll the server for live updates while a meeting is setup / in progress. */
+    private static readonly LIVE_POLL_INTERVAL_MS = 10000;
+
+    /** Timestamp of the last successful live refresh (drives the "Live" indicator). */
+    liveUpdatedAt: Date | null = null;
+
+    /** True while the realtime socket is connected (polling falls back when false). */
+    realtimeConnected = false;
+
     // Summary collapse state
     fundedCollapsed = false;
     inConsiderationSummaryCollapsed = true;
@@ -148,6 +158,7 @@ export class MeetingDetailComponent implements OnInit, AfterViewInit {
         private route: ActivatedRoute,
         private router: Router,
         private meetingService: MeetingService,
+        private realtime: MeetingRealtimeService,
         private authService: AuthService,
         private dialog: MatDialog,
         private snackBar: MatSnackBar,
@@ -224,12 +235,30 @@ export class MeetingDetailComponent implements OnInit, AfterViewInit {
             )
             .subscribe((id) => {
                 this.meetingId = id;
+                this.realtime.joinMeeting(id);
                 this.loadMeetingDetails(id);
+            });
+
+        // Live updates pushed by the server after any meeting mutation.
+        this.realtime
+            .meetingUpdates()
+            .pipe(takeUntilDestroyed(this.destroyRef))
+            .subscribe((meeting) => this.applyLiveMeetingUpdate(meeting));
+
+        this.realtime
+            .connected()
+            .pipe(takeUntilDestroyed(this.destroyRef))
+            .subscribe((connected) => {
+                this.realtimeConnected = connected;
+                this._changeDetectorRef.markForCheck();
             });
 
         this.destroyRef.onDestroy(() => {
             this.clearSetupBudgetNotesSavedTimer();
             this.clearAllocationsSavedTimer();
+            if (this.meetingId) {
+                this.realtime.leaveMeeting(this.meetingId);
+            }
         });
 
         this.setupSearchSubject
@@ -309,6 +338,24 @@ export class MeetingDetailComponent implements OnInit, AfterViewInit {
                     const msg = err.error?.message || 'Error saving allocations';
                     this.snackBar.open(msg, 'Close', { duration: 5000 });
                 },
+            });
+
+        // Live sync: while a meeting is being set up or run, poll for the latest
+        // state so directors watching see the president's edits without refreshing.
+        interval(MeetingDetailComponent.LIVE_POLL_INTERVAL_MS)
+            .pipe(
+                filter(() => this.canLivePoll()),
+                switchMap(() =>
+                    this.meetingService.getMeeting(this.meetingId).pipe(
+                        catchError(() => of(null))
+                    )
+                ),
+                takeUntilDestroyed(this.destroyRef)
+            )
+            .subscribe((meeting) => {
+                if (meeting) {
+                    this.applyLiveMeetingUpdate(meeting);
+                }
             });
     }
 
@@ -518,6 +565,82 @@ export class MeetingDetailComponent implements OnInit, AfterViewInit {
         this.pendingAllocations.clear();
         this.allocationAmountDrafts.clear();
         this.hasUnsavedChanges = false;
+    }
+
+    /**
+     * True when it's safe to poll the server for a live refresh: the meeting is
+     * loaded, still in a live state (setup / in progress), the tab is visible, and
+     * the current user is not in the middle of editing (so we never clobber edits).
+     */
+    private canLivePoll(): boolean {
+        if (!this.loaded || !this.meetingId || !this.meeting) {
+            return false;
+        }
+        // Realtime socket is authoritative; only poll as a fallback when it's down.
+        if (this.realtimeConnected) {
+            return false;
+        }
+        if (typeof document !== 'undefined' && document.hidden) {
+            return false;
+        }
+        const status = this.meeting.status;
+        if (status !== 'setup' && status !== 'in_progress') {
+            return false;
+        }
+        return !this.isLocallyEditing();
+    }
+
+    /** Any local editing/in-flight state that a live refresh must not overwrite. */
+    private isLocallyEditing(): boolean {
+        return (
+            this.hasUnsavedChanges ||
+            this.pendingAllocations.size > 0 ||
+            this.editingInProgressBudget ||
+            this.editingCompletedMeeting ||
+            this.setupBudgetNotesSaving ||
+            this.allocationsSaving ||
+            this.bulkAllocationActionInFlight ||
+            this.allocationActiveToggleInFlight.size > 0 ||
+            this.syncAllocationsInFlight ||
+            this.focusedAllocationInputId !== null
+        );
+    }
+
+    /**
+     * Apply a polled meeting payload without disturbing local edits, search, or sort.
+     * Editable drafts (budget/notes) are only overwritten for read-only viewers.
+     */
+    private applyLiveMeetingUpdate(meeting: any): void {
+        if (!meeting || !this.meeting) {
+            return;
+        }
+        // Re-check: the user may have started editing while the request was in flight.
+        if (this.isLocallyEditing()) {
+            return;
+        }
+        // Ignore stale/mismatched responses (e.g. after navigating to another meeting).
+        if (this.meetingId && String(meeting._id) !== String(this.meetingId)) {
+            return;
+        }
+
+        this.meeting = meeting;
+        if (!this.canEditBudget()) {
+            this.totalBudget = meeting.totalBudget;
+            this.meetingNotes = meeting.notes || '';
+        }
+        this.recalcTotals();
+        this.liveUpdatedAt = new Date();
+        this.refreshSummaryIfCompleted();
+        this._changeDetectorRef.markForCheck();
+    }
+
+    /** Show the "Live" indicator while a meeting is actively being set up or run. */
+    get showLiveIndicator(): boolean {
+        return (
+            this.loaded &&
+            !!this.meeting &&
+            (this.meeting.status === 'setup' || this.meeting.status === 'in_progress')
+        );
     }
 
     /** Whether to run sync-eligible-proposals for the current meeting + role. */

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -2,5 +2,6 @@ export const environment = {
     production: true,
     envName: 'prod',
     apiUrl: 'https://api.hagenfamilyfoundation.org',
+    socketUrl: 'https://api.hagenfamilyfoundation.org',
     hmr: false,
 };

--- a/src/environments/environment.staging.ts
+++ b/src/environments/environment.staging.ts
@@ -3,5 +3,6 @@ export const environment = {
     production: false,
     envName: 'staging',
     apiUrl: 'https://staging-api.hagenfamilyfoundation.org',
+    socketUrl: 'https://staging-api.hagenfamilyfoundation.org',
     hmr: false,
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -10,6 +10,11 @@ export const environment = {
      * Avoids calling `http://localhost:1337` from the browser (CORS / localhost quirks).
      */
     apiUrl: '/api',
+    /**
+     * Socket.IO base URL. Empty string = same origin, so the Angular dev server
+     * proxies `/socket.io` to the Node server (see `proxy.conf.json`).
+     */
+    socketUrl: '',
     /** For dev-only messages — actual HTTP base is `apiUrl` above */
     backendOriginLabel: 'http://127.0.0.1:1337',
 };

--- a/src/proxy.conf.json
+++ b/src/proxy.conf.json
@@ -6,5 +6,11 @@
     "pathRewrite": {
       "^/api": ""
     }
+  },
+  "/socket.io/**": {
+    "target": "http://127.0.0.1:1337",
+    "secure": false,
+    "changeOrigin": true,
+    "ws": true
   }
 }


### PR DESCRIPTION
Promote current develop to staging for QA.

Includes real-time meeting sync (MeetingRealtimeService, live indicator, polling fallback) targeting the staging API socket URL. Paired with thff-be develop→staging.

Made with [Cursor](https://cursor.com)