### PR TITLE
fix(meetings): use long-polling transport for App Runner

### DIFF
--- a/src/app/core/services/admin/meeting-realtime.service.ts
+++ b/src/app/core/services/admin/meeting-realtime.service.ts
@@ -30,8 +30,9 @@ export class MeetingRealtimeService {
 
         this.socket = io(url as string, {
             auth: { token },
-            // WebSocket-only to match the server (no sticky sessions needed).
-            transports: ['websocket'],
+            // HTTP long-polling first (App Runner has no WebSocket support), then
+            // auto-upgrade to WebSocket where available. Matches the server config.
+            transports: ['polling', 'websocket'],
             reconnection: true,
             reconnectionDelay: 1000,
             reconnectionDelayMax: 8000,


### PR DESCRIPTION
Match the backend: App Runner has no WebSocket support, so connect with HTTP long-polling first (near-instant) and auto-upgrade to WebSocket only where the platform allows. Paired with thff-be.

Made with [Cursor](https://cursor.com)