### PR TITLE
feat(meetings): richer live feedback for meeting watchers

### DIFF
--- a/src/app/modules/pages/director/meeting-detail/meeting-detail.component.html
+++ b/src/app/modules/pages/director/meeting-detail/meeting-detail.component.html
@@ -18,11 +18,20 @@
                         {{ getStatusLabel(meeting.status) }}
                     </span>
                     <span *ngIf="showLiveIndicator"
-                          class="inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-700 dark:bg-red-900 dark:bg-opacity-40 dark:text-red-300"
-                          [matTooltip]="liveUpdatedAt ? ('Updated ' + (liveUpdatedAt | date:'h:mm:ss a')) : 'Updates automatically'"
-                          aria-label="Live meeting — updates automatically">
-                        <span class="meeting-live-dot"></span>
-                        Live
+                          class="inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-full text-xs font-medium"
+                          [ngClass]="realtimeConnected
+                              ? 'bg-green-100 text-green-700 dark:bg-green-900 dark:bg-opacity-40 dark:text-green-300'
+                              : 'bg-amber-100 text-amber-700 dark:bg-amber-900 dark:bg-opacity-40 dark:text-amber-300'"
+                          [matTooltip]="realtimeConnected
+                              ? 'Connected — grant and budget changes appear instantly'
+                              : 'Connection dropped — refreshing every few seconds until it reconnects'"
+                          [attr.aria-label]="realtimeConnected ? 'Live — updates automatically' : 'Reconnecting — updates every few seconds'">
+                        <span class="meeting-live-dot" [class.meeting-live-dot--idle]="!realtimeConnected"></span>
+                        {{ liveStatusLabel }}
+                    </span>
+                    <span *ngIf="showLiveIndicator && liveAgoLabel"
+                          class="text-xs text-gray-400 dark:text-gray-500">
+                        {{ liveAgoLabel }}
                     </span>
                 </div>
                 <div class="flex flex-wrap items-center gap-2">
@@ -288,7 +297,8 @@
                         </div>
                     </ng-container>
                     <ng-template #budgetStatDisplay>
-                        <span class="text-2xl font-bold mt-1">{{ budgetForDisplay() | currency:'USD':'symbol':'1.0-0' }}</span>
+                        <span class="text-2xl font-bold mt-1 meeting-stat-value"
+                              [class.meeting-stat-value--flash]="budgetJustChanged">{{ budgetForDisplay() | currency:'USD':'symbol':'1.0-0' }}</span>
                     </ng-template>
                     <span *ngIf="previousBudgetAmount() != null"
                           class="text-xs text-gray-400 mt-0.5">
@@ -298,15 +308,19 @@
 
                 <fuse-card class="flex flex-col p-5">
                     <span class="text-xs font-medium text-gray-500 uppercase tracking-wider">Total Allocated</span>
-                    <span class="text-2xl font-bold mt-1" [ngClass]="{ 'text-red-600': totalAllocated > budgetForDisplay() }">
+                    <span class="text-2xl font-bold mt-1 meeting-stat-value"
+                          [class.text-red-600]="totalAllocated > budgetForDisplay()"
+                          [class.meeting-stat-value--flash]="allocatedJustChanged">
                         {{ totalAllocated | currency:'USD':'symbol':'1.0-0' }}
                     </span>
                 </fuse-card>
 
                 <fuse-card class="flex flex-col p-5">
                     <span class="text-xs font-medium text-gray-500 uppercase tracking-wider">Remaining</span>
-                    <span class="text-2xl font-bold mt-1"
-                          [ngClass]="{ 'text-red-600': remainingBudget < 0, 'text-green-600': remainingBudget > 0 }">
+                    <span class="text-2xl font-bold mt-1 meeting-stat-value"
+                          [class.text-red-600]="remainingBudget < 0"
+                          [class.text-green-600]="remainingBudget > 0"
+                          [class.meeting-stat-value--flash]="remainingJustChanged">
                         {{ remainingBudget | currency:'USD':'symbol':'1.0-0' }}
                     </span>
                 </fuse-card>
@@ -881,8 +895,9 @@
                                            (input)="onAllocationAmountInput(row._id, $event)">
                                 </div>
                                 <span *ngIf="!isPresidentOrAdmin || (meeting.status !== 'in_progress' && !(meeting.status === 'completed' && editingCompletedMeeting))"
-                                      class="font-semibold"
-                                      [ngClass]="{ 'text-green-600': row.amountGranted > 0 }">
+                                      class="font-semibold meeting-amount"
+                                      [class.text-green-600]="row.amountGranted > 0"
+                                      [class.meeting-amount--flash]="isAllocationRecentlyChanged(row)">
                                     {{ (row.amountGranted || 0) | currency:'USD':'symbol':'1.0-0' }}
                                 </span>
                             </mat-cell>
@@ -904,7 +919,8 @@
                         </ng-container>
 
                         <mat-header-row *matHeaderRowDef="getActiveColumns()"></mat-header-row>
-                        <mat-row *matRowDef="let row; columns: getActiveColumns(); trackBy: trackAllocationRow"></mat-row>
+                        <mat-row *matRowDef="let row; columns: getActiveColumns(); trackBy: trackAllocationRow"
+                                 [class.meeting-row--flash]="isAllocationRecentlyChanged(row)"></mat-row>
                     </mat-table>
 
                     <mat-paginator

--- a/src/app/modules/pages/director/meeting-detail/meeting-detail.component.scss
+++ b/src/app/modules/pages/director/meeting-detail/meeting-detail.component.scss
@@ -22,8 +22,84 @@
     }
 }
 
+/* Steady (non-pulsing) dot while reconnecting / on the polling fallback. */
+.meeting-live-dot--idle {
+    animation: none;
+    opacity: 0.65;
+}
+
+/* Transient highlight on a stat value when it updates live (draws the watcher's eye). */
+.meeting-stat-value {
+    display: inline-block;
+    padding: 0 0.35rem;
+    margin: 0 -0.35rem;
+    border-radius: 0.375rem;
+}
+
+.meeting-stat-value--flash {
+    animation: meeting-value-flash 1.8s ease-out;
+}
+
+@keyframes meeting-value-flash {
+    0% {
+        background-color: rgba(16, 185, 129, 0.30);
+    }
+    100% {
+        background-color: transparent;
+    }
+}
+
+/* Transient highlight on a grant row that just changed. */
+:host ::ng-deep .mat-row.meeting-row--flash {
+    animation: meeting-row-flash 2s ease-out;
+}
+
+@keyframes meeting-row-flash {
+    0%,
+    25% {
+        background-color: rgba(16, 185, 129, 0.28);
+    }
+    100% {
+        background-color: transparent;
+    }
+}
+
+/* Strong, obvious pop on the grant amount itself when it changes live. */
+.meeting-amount {
+    display: inline-block;
+    border-radius: 0.375rem;
+    padding: 0.05rem 0.4rem;
+    margin: -0.05rem -0.4rem;
+}
+
+.meeting-amount--flash {
+    animation: meeting-amount-flash 2s ease-out;
+}
+
+@keyframes meeting-amount-flash {
+    0% {
+        background-color: rgba(16, 185, 129, 0.55);
+        color: rgb(6, 95, 70);
+        transform: scale(1.18);
+    }
+    30% {
+        background-color: rgba(16, 185, 129, 0.45);
+        transform: scale(1.18);
+    }
+    100% {
+        background-color: transparent;
+        transform: scale(1);
+    }
+}
+
 @media (prefers-reduced-motion: reduce) {
     .meeting-live-dot {
+        animation: none;
+    }
+
+    .meeting-stat-value--flash,
+    .meeting-amount--flash,
+    :host ::ng-deep .mat-row.meeting-row--flash {
         animation: none;
     }
 }

--- a/src/app/modules/pages/director/meeting-detail/meeting-detail.component.ts
+++ b/src/app/modules/pages/director/meeting-detail/meeting-detail.component.ts
@@ -139,6 +139,17 @@ export class MeetingDetailComponent implements OnInit, AfterViewInit {
     /** True while the realtime socket is connected (polling falls back when false). */
     realtimeConnected = false;
 
+    /** True once the socket has connected at least once (so we say "Connecting…" vs "Reconnecting…"). */
+    private hasEverConnected = false;
+
+    /** Allocation ids whose grant/status just changed on a live update (drives the row flash). */
+    readonly recentlyChangedAllocationIds = new Set<string>();
+    /** Transient highlight flags for the stat cards after a live update. */
+    budgetJustChanged = false;
+    allocatedJustChanged = false;
+    remainingJustChanged = false;
+    private liveChangeFlashTimer: ReturnType<typeof setTimeout> | null = null;
+
     // Summary collapse state
     fundedCollapsed = false;
     inConsiderationSummaryCollapsed = true;
@@ -250,12 +261,24 @@ export class MeetingDetailComponent implements OnInit, AfterViewInit {
             .pipe(takeUntilDestroyed(this.destroyRef))
             .subscribe((connected) => {
                 this.realtimeConnected = connected;
+                if (connected) {
+                    this.hasEverConnected = true;
+                }
                 this._changeDetectorRef.markForCheck();
             });
+
+        // Keep the "updated N ago" label current while a meeting is live.
+        interval(1000)
+            .pipe(
+                filter(() => this.showLiveIndicator && !!this.liveUpdatedAt),
+                takeUntilDestroyed(this.destroyRef)
+            )
+            .subscribe(() => this._changeDetectorRef.markForCheck());
 
         this.destroyRef.onDestroy(() => {
             this.clearSetupBudgetNotesSavedTimer();
             this.clearAllocationsSavedTimer();
+            this.clearLiveChangeFlashTimer();
             if (this.meetingId) {
                 this.realtime.leaveMeeting(this.meetingId);
             }
@@ -623,6 +646,16 @@ export class MeetingDetailComponent implements OnInit, AfterViewInit {
             return;
         }
 
+        // Snapshot the current values so we can highlight exactly what changed.
+        const prevGranted = new Map<string, number>();
+        const prevActive = new Map<string, boolean>();
+        for (const a of this.meeting.allocations || []) {
+            prevGranted.set(String(a._id), Number(a.amountGranted || 0));
+            prevActive.set(String(a._id), a.activeInMeeting !== false);
+        }
+        const prevBudget = Number(this.meeting.totalBudget || 0);
+        const prevAllocated = this.totalAllocated;
+
         this.meeting = meeting;
         if (!this.canEditBudget()) {
             this.totalBudget = meeting.totalBudget;
@@ -630,8 +663,124 @@ export class MeetingDetailComponent implements OnInit, AfterViewInit {
         }
         this.recalcTotals();
         this.liveUpdatedAt = new Date();
+        this.flagLiveChanges(prevGranted, prevActive, prevBudget, prevAllocated);
         this.refreshSummaryIfCompleted();
         this._changeDetectorRef.markForCheck();
+    }
+
+    /** Relative "updated N ago" label for watchers; empty until the first live update. */
+    get liveAgoLabel(): string {
+        if (!this.liveUpdatedAt) {
+            return '';
+        }
+        const secs = Math.max(0, Math.floor((Date.now() - this.liveUpdatedAt.getTime()) / 1000));
+        if (secs < 5) {
+            return 'Updated just now';
+        }
+        if (secs < 60) {
+            return `Updated ${secs}s ago`;
+        }
+        const mins = Math.floor(secs / 60);
+        return mins === 1 ? 'Updated 1 min ago' : `Updated ${mins} min ago`;
+    }
+
+    /** Badge label reflecting the real connection state (not just "live during setup"). */
+    get liveStatusLabel(): string {
+        if (this.realtimeConnected) {
+            return 'Live';
+        }
+        return this.hasEverConnected ? 'Reconnecting…' : 'Connecting…';
+    }
+
+    isAllocationRecentlyChanged(row: any): boolean {
+        return !!row && this.recentlyChangedAllocationIds.has(String(row._id));
+    }
+
+    private liveChangeProposalTitle(allocation: any): string {
+        const title = allocation?.proposal?.projectTitle;
+        return title && String(title).trim() ? String(title).trim() : 'A proposal';
+    }
+
+    /**
+     * Toast for watchers when the president moves proposals to / from the set aside
+     * list. The person who performed the action is guarded out upstream (their own
+     * edit is in flight), so this only fires for people watching.
+     */
+    private notifyAllocationListChanges(setAside: string[], restored: string[]): void {
+        const parts: string[] = [];
+        if (setAside.length === 1) {
+            parts.push(`“${setAside[0]}” was set aside`);
+        } else if (setAside.length > 1) {
+            parts.push(`${setAside.length} proposals were set aside`);
+        }
+        if (restored.length === 1) {
+            parts.push(`“${restored[0]}” moved back to consideration`);
+        } else if (restored.length > 1) {
+            parts.push(`${restored.length} proposals moved back to consideration`);
+        }
+        if (parts.length > 0) {
+            this.snackBar.open(parts.join(' · '), 'Close', { duration: 4000 });
+        }
+    }
+
+    private clearLiveChangeFlashTimer(): void {
+        if (this.liveChangeFlashTimer !== null) {
+            clearTimeout(this.liveChangeFlashTimer);
+            this.liveChangeFlashTimer = null;
+        }
+    }
+
+    /** Diff the applied update against the prior state and trigger the transient highlights. */
+    private flagLiveChanges(
+        prevGranted: Map<string, number>,
+        prevActive: Map<string, boolean>,
+        prevBudget: number,
+        prevAllocated: number
+    ): void {
+        const changedIds = new Set<string>();
+        const setAsideTitles: string[] = [];
+        const restoredTitles: string[] = [];
+        for (const a of this.meeting?.allocations || []) {
+            const id = String(a._id);
+            const grantedChanged = Number(a.amountGranted || 0) !== (prevGranted.get(id) ?? 0);
+            const wasActive = prevActive.get(id) ?? true;
+            const nowActive = a.activeInMeeting !== false;
+            const activeChanged = prevActive.has(id) && nowActive !== wasActive;
+            const isNew = !prevGranted.has(id);
+            if (grantedChanged || activeChanged || isNew) {
+                changedIds.add(id);
+            }
+            if (activeChanged && !nowActive) {
+                setAsideTitles.push(this.liveChangeProposalTitle(a));
+            } else if (activeChanged && nowActive) {
+                restoredTitles.push(this.liveChangeProposalTitle(a));
+            }
+        }
+
+        this.notifyAllocationListChanges(setAsideTitles, restoredTitles);
+
+        const budgetChanged = Number(this.meeting?.totalBudget || 0) !== prevBudget;
+        const allocatedChanged = this.totalAllocated !== prevAllocated;
+
+        if (changedIds.size === 0 && !budgetChanged && !allocatedChanged) {
+            return;
+        }
+
+        this.recentlyChangedAllocationIds.clear();
+        changedIds.forEach((id) => this.recentlyChangedAllocationIds.add(id));
+        this.budgetJustChanged = budgetChanged;
+        this.allocatedJustChanged = allocatedChanged;
+        this.remainingJustChanged = budgetChanged || allocatedChanged;
+
+        this.clearLiveChangeFlashTimer();
+        this.liveChangeFlashTimer = setTimeout(() => {
+            this.recentlyChangedAllocationIds.clear();
+            this.budgetJustChanged = false;
+            this.allocatedJustChanged = false;
+            this.remainingJustChanged = false;
+            this.liveChangeFlashTimer = null;
+            this._changeDetectorRef.markForCheck();
+        }, 1800);
     }
 
     /** Show the "Live" indicator while a meeting is actively being set up or run. */


### PR DESCRIPTION
## Summary
Makes it obvious to directors watching a live meeting what the president just changed.

- Connection-aware status badge (green **Live** vs amber **Reconnecting…/Connecting…**) + ticking "Updated Ns ago" freshness label
- Grant row flash + a stronger scale/highlight pop on the changed amount value
- Brief highlight on the Budget / Allocated / Remaining stat cards when they move
- Toast when a proposal is set aside or restored (bulk summarized); the actor is guarded out so no duplicates
- Respects prefers-reduced-motion

Frontend-only; builds clean on the staging configuration.

## Test plan
- [ ] Two browsers on the same in-progress meeting (president + director)
- [ ] President edits a grant amount → director sees the amount pop + row flash
- [ ] President sets a proposal aside → director gets a toast; restore → toast
- [ ] Drop the socket → badge shows "Reconnecting…" and still updates via polling

Made with [Cursor](https://cursor.com)