### PR TITLE
fix(meetings): keep History panel header visible (5.6.6)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thff-fuse2",
-  "version": "5.6.5",
+  "version": "5.6.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "thff-fuse2",
-      "version": "5.6.5",
+      "version": "5.6.6",
       "hasInstallScript": true,
       "license": "https://themeforest.net/licenses/standard",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thff-fuse2",
-  "version": "5.6.5",
+  "version": "5.6.6",
   "description": "THFF FE built with Fuse - Angular Admin Template and Starter Project",
   "author": "lcborn4@gmail.com",
   "license": "https://themeforest.net/licenses/standard",

--- a/src/app/modules/pages/director/meeting-detail/meeting-detail.component.html
+++ b/src/app/modules/pages/director/meeting-detail/meeting-detail.component.html
@@ -54,6 +54,7 @@
 
         <!-- Unified sticky top bar: compact stats + bulk selection (fixed below app nav) -->
     <div *ngIf="loaded && meeting"
+         #topStickyBar
          class="meeting-top-sticky bg-card rounded-none"
          [class.meeting-top-sticky--visible]="topStickyBarVisible"
          [style.top.px]="layoutHeaderBottomPx"
@@ -1142,8 +1143,10 @@
 
                 </div>
 
-                <aside class="meeting-workspace__history" aria-label="Meeting history">
-                    <fuse-card class="meeting-history-panel flex flex-col overflow-hidden">
+                <aside class="meeting-workspace__history" aria-label="Meeting history"
+                       [style.top.px]="historyTopPx">
+                    <fuse-card class="meeting-history-panel flex flex-col overflow-hidden"
+                               [style.maxHeight.px]="historyMaxHeightPx">
                         <div class="meeting-history-panel__header">
                             <h3 class="text-sm font-semibold m-0 text-gray-800 dark:text-gray-100">History</h3>
                             <span class="text-xs text-gray-500">{{ meetingHistoryEvents().length }}</span>

--- a/src/app/modules/pages/director/meeting-detail/meeting-detail.component.ts
+++ b/src/app/modules/pages/director/meeting-detail/meeting-detail.component.ts
@@ -161,7 +161,13 @@ export class MeetingDetailComponent implements OnInit, AfterViewInit {
     /** Measured bottom edge of the app layout header (px); 0 when header has scrolled off. */
     layoutHeaderBottomPx = 0;
 
+    /** Sticky top offset + max height (px) for the History panel so its header always
+     *  clears the fixed stats/actions bar instead of being hidden behind it. */
+    historyTopPx = 88;
+    historyMaxHeightPx: number | null = null;
+
     @ViewChild('statsStickySentinel') statsStickySentinel?: ElementRef<HTMLElement>;
+    @ViewChild('topStickyBar') topStickyBar?: ElementRef<HTMLElement>;
 
     displayedColumns = ['projectTitle', 'organization', 'sponsor', 'createdOn', 'amountRequested', 'amountGranted'];
 
@@ -183,6 +189,7 @@ export class MeetingDetailComponent implements OnInit, AfterViewInit {
     ngAfterViewInit(): void {
         this.measureLayoutHeader();
         this.updateStatsStickyVisible();
+        this.updateHistoryLayout();
     }
 
     @HostListener('window:scroll')
@@ -190,6 +197,39 @@ export class MeetingDetailComponent implements OnInit, AfterViewInit {
     onWindowScrollOrResize(): void {
         this.measureLayoutHeader();
         this.updateStatsStickyVisible();
+        this.updateHistoryLayout();
+    }
+
+    /**
+     * Pin the History panel just below the fixed stats/actions bar so its header
+     * stays visible while the list scrolls, and cap its height to the space left
+     * in the viewport. Recomputed on scroll/resize since the bar height varies.
+     */
+    private updateHistoryLayout(): void {
+        if (typeof window === 'undefined') {
+            return;
+        }
+        // Below the lg breakpoint the panel stacks (static) and CSS caps its height.
+        if (window.innerWidth < 1024) {
+            if (this.historyMaxHeightPx !== null || this.historyTopPx !== 88) {
+                this.historyMaxHeightPx = null;
+                this.historyTopPx = 88;
+                this._changeDetectorRef.markForCheck();
+            }
+            return;
+        }
+        const gap = 12;
+        const barHeight =
+            this.topStickyBarVisible && this.topStickyBar?.nativeElement
+                ? Math.round(this.topStickyBar.nativeElement.getBoundingClientRect().height)
+                : 0;
+        const top = this.layoutHeaderBottomPx + barHeight + gap;
+        const maxHeight = Math.max(180, Math.round(window.innerHeight - top - gap));
+        if (top !== this.historyTopPx || maxHeight !== this.historyMaxHeightPx) {
+            this.historyTopPx = top;
+            this.historyMaxHeightPx = maxHeight;
+            this._changeDetectorRef.markForCheck();
+        }
     }
 
     private measureLayoutHeader(): void {
@@ -557,6 +597,7 @@ export class MeetingDetailComponent implements OnInit, AfterViewInit {
                     setTimeout(() => {
                         this.measureLayoutHeader();
                         this.updateStatsStickyVisible();
+                        this.updateHistoryLayout();
                         this.tryRestoreSetupStepIndex();
                     });
                 })


### PR DESCRIPTION
Measures the fixed stats/actions bar height and pins the History panel just below it so the 'History' header no longer gets covered. Caps panel height to the remaining viewport; mobile stacking unchanged. Bumps to 5.6.6.

Made with [Cursor](https://cursor.com)