### PR TITLE
feat(meeting): add a proposal to a meeting + fix submission-year toggle 401 (THFF-155)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thff-fuse2",
-  "version": "5.6.14",
+  "version": "5.6.15",
   "description": "THFF FE built with Fuse - Angular Admin Template and Starter Project",
   "author": "lcborn4@gmail.com",
   "license": "https://themeforest.net/licenses/standard",

--- a/src/app/core/auth/auth.interceptor.ts
+++ b/src/app/core/auth/auth.interceptor.ts
@@ -17,7 +17,7 @@ export class AuthInterceptor implements HttpInterceptor {
         next: HttpHandler
     ): Observable<HttpEvent<any>> {
         // Public endpoints must work without a session (e.g. home page grant-cycle status).
-        const newReq = this._isPublicEndpoint(req.url) ? req : this._addToken(req);
+        const newReq = this._isPublicEndpoint(req) ? req : this._addToken(req);
 
         // Response
         return next.handle(newReq).pipe(
@@ -33,7 +33,7 @@ export class AuthInterceptor implements HttpInterceptor {
                         req.url.includes(endpoint)
                     );
 
-                    if (isSkipEndpoint || this._isPublicEndpoint(req.url)) {
+                    if (isSkipEndpoint || this._isPublicEndpoint(req)) {
                         return throwError(() => error);
                     }
 
@@ -47,12 +47,16 @@ export class AuthInterceptor implements HttpInterceptor {
     }
 
     /** Endpoints that must not require auth (landing page grant-cycle status, health checks, referral validate). */
-    private _isPublicEndpoint(url: string): boolean {
+    private _isPublicEndpoint(req: HttpRequest<any>): boolean {
+        const url = req.url;
         if (url.includes('/referral-code/validate/')) {
             return true;
         }
-        const publicEndpoints = ['/submission-year', '/health'];
-        return publicEndpoints.some((endpoint) => url.includes(endpoint));
+        // Only GET submission-year endpoints are public. PUT /toggle and POST / require auth.
+        if (url.includes('/submission-year')) {
+            return req.method === 'GET';
+        }
+        return url.includes('/health');
     }
 
     /**

--- a/src/app/core/services/admin/meeting.service.ts
+++ b/src/app/core/services/admin/meeting.service.ts
@@ -53,6 +53,11 @@ export class MeetingService {
         return this.http.post(`${this.apiUrl}/meeting/${id}/sync-eligible-proposals`, {});
     }
 
+    /** Hand-add a single proposal to the meeting regardless of its year. Idempotent. */
+    addProposalToMeeting(id: string, proposalId: string): Observable<any> {
+        return this.http.post(`${this.apiUrl}/meeting/${id}/allocation`, { proposalId });
+    }
+
     createMeeting(data: { submissionYear: string; year: number; totalBudget?: number; notes?: string }): Observable<any> {
         return this.http.post(`${this.apiUrl}/meeting`, data);
     }

--- a/src/app/modules/pages/director/director.module.ts
+++ b/src/app/modules/pages/director/director.module.ts
@@ -39,6 +39,7 @@ import { SolicitationPreviewSendDialogComponent } from './solicitation-emails/so
 import { MeetingComponent } from './meeting/meeting.component';
 import { CreateMeetingDialogComponent } from './meeting/create-meeting-dialog.component';
 import { MeetingDetailComponent } from './meeting-detail/meeting-detail.component';
+import { AddProposalDialogComponent } from './meeting-detail/add-proposal-dialog.component';
 import { MeetingContactsComponent } from './meeting-contacts/meeting-contacts.component';
 import { MeetingAfterComponent } from './meeting-after/meeting-after.component';
 import { GrantProposalEmailListComponent } from './meeting-after/grant-proposal-email-list.component';
@@ -46,7 +47,7 @@ import { SentGrantEmailViewDialogComponent } from './meeting-after/sent-grant-em
 import { AutosaveStatusComponent } from 'app/common/components/autosave-status/autosave-status.component';
 import { ConfirmDialogComponent } from 'app/common/components/confirm-dialog/confirm-dialog.component';
 @NgModule({
-    declarations: [DirectorComponent, OrganizationsComponent, ProposalsComponent, VotingComponent, SubmissionYearsComponent, ClosePortalDialogComponent, ReferralLinksComponent, SolicitationEmailsComponent, SolicitationEmailPreviewDialogComponent, SolicitationPreviewSendDialogComponent, MeetingComponent, CreateMeetingDialogComponent, MeetingDetailComponent, MeetingContactsComponent, MeetingAfterComponent, GrantProposalEmailListComponent, SentGrantEmailViewDialogComponent],
+    declarations: [DirectorComponent, OrganizationsComponent, ProposalsComponent, VotingComponent, SubmissionYearsComponent, ClosePortalDialogComponent, ReferralLinksComponent, SolicitationEmailsComponent, SolicitationEmailPreviewDialogComponent, SolicitationPreviewSendDialogComponent, MeetingComponent, CreateMeetingDialogComponent, MeetingDetailComponent, AddProposalDialogComponent, MeetingContactsComponent, MeetingAfterComponent, GrantProposalEmailListComponent, SentGrantEmailViewDialogComponent],
     imports: [
         RouterModule.forChild(directorRoutes),
         CommonModule,

--- a/src/app/modules/pages/director/meeting-detail/add-proposal-dialog.component.ts
+++ b/src/app/modules/pages/director/meeting-detail/add-proposal-dialog.component.ts
@@ -1,0 +1,229 @@
+import { ChangeDetectorRef, Component, Inject, OnInit } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { Subject } from 'rxjs';
+import { debounceTime, takeUntil } from 'rxjs/operators';
+import { MeetingService } from 'app/core/services/admin/meeting.service';
+import { ProposalService } from 'app/core/services/proposal/proposal.service';
+
+export interface AddProposalDialogData {
+    meetingId: string;
+    /** Meeting year — the default year to search, but the director can change it. */
+    year: number;
+    /** Proposal Mongo `_id`s already on the meeting (hidden / marked as added). */
+    existingProposalIds: string[];
+}
+
+/**
+ * Lets a president/admin search proposals (by year + title) and hand-add one to the meeting,
+ * regardless of the proposal's year — e.g. a proposal submitted after the portal closed.
+ * On success the dialog closes with the updated meeting payload.
+ */
+@Component({
+    standalone: false,
+    selector: 'app-add-proposal-dialog',
+    template: `
+        <h2 mat-dialog-title class="text-lg font-semibold">Add a proposal to this meeting</h2>
+        <mat-dialog-content class="min-w-[28rem]">
+            <p class="text-sm text-gray-500 dark:text-gray-400 mb-4">
+                Search by title, organization, sponsor, or proposal ID and add a proposal to this
+                meeting. Pick a different year to add a proposal submitted for another cycle.
+            </p>
+
+            <div class="flex gap-3 items-end mb-3">
+                <mat-form-field class="w-28" appearance="fill">
+                    <mat-label>Year</mat-label>
+                    <input matInput type="number" [(ngModel)]="year" (ngModelChange)="onYearChange()" />
+                </mat-form-field>
+                <mat-form-field class="flex-1" appearance="fill">
+                    <mat-label>Search</mat-label>
+                    <input
+                        matInput
+                        [(ngModel)]="filter"
+                        (ngModelChange)="onFilterChange($event)"
+                        placeholder="Title, organization, sponsor, or proposal ID"
+                    />
+                    <mat-icon matSuffix>search</mat-icon>
+                </mat-form-field>
+            </div>
+
+            <div class="min-h-[10rem]">
+                <div *ngIf="loading" class="flex justify-center py-8">
+                    <mat-progress-spinner mode="indeterminate" diameter="32"></mat-progress-spinner>
+                </div>
+
+                <div
+                    *ngIf="!loading && results.length === 0"
+                    class="text-sm text-gray-500 dark:text-gray-400 py-8 text-center"
+                >
+                    No submitted proposals found for {{ year }}.
+                </div>
+
+                <div *ngIf="!loading && results.length > 0" class="flex flex-col divide-y divide-gray-200 dark:divide-gray-700">
+                    <div
+                        *ngFor="let p of results"
+                        class="flex items-center justify-between gap-3 py-2"
+                    >
+                        <div class="min-w-0">
+                            <div class="font-medium truncate">{{ p.projectTitle || 'Untitled' }}</div>
+                            <div class="text-xs text-gray-500 dark:text-gray-400 truncate">
+                                {{ orgLabel(p) }}
+                                <span *ngIf="p.amountRequested != null">
+                                    · Requested {{ p.amountRequested | currency }}
+                                </span>
+                                <span *ngIf="p.proposalID"> · ID {{ p.proposalID }}</span>
+                            </div>
+                        </div>
+                        <button
+                            *ngIf="!isOnMeeting(p)"
+                            mat-flat-button
+                            color="primary"
+                            [disabled]="!!addingId"
+                            (click)="add(p)"
+                        >
+                            <mat-progress-spinner
+                                *ngIf="addingId === proposalId(p)"
+                                mode="indeterminate"
+                                diameter="16"
+                                class="inline-block mr-1"
+                            ></mat-progress-spinner>
+                            Add
+                        </button>
+                        <span *ngIf="isOnMeeting(p)" class="text-xs text-green-600 dark:text-green-400 flex items-center gap-1">
+                            <mat-icon class="icon-size-4">check</mat-icon> On meeting
+                        </span>
+                    </div>
+                </div>
+            </div>
+        </mat-dialog-content>
+        <mat-dialog-actions align="end" class="mt-2">
+            <button mat-stroked-button (click)="close()" [disabled]="!!addingId">Done</button>
+        </mat-dialog-actions>
+    `,
+})
+export class AddProposalDialogComponent implements OnInit {
+    year: number;
+    filter = '';
+    loading = false;
+    results: any[] = [];
+    /** Proposal `_id` currently being added (drives the row spinner / disabled state). */
+    addingId: string | null = null;
+
+    private readonly existing = new Set<string>();
+    private readonly _search$ = new Subject<void>();
+    private readonly _destroy$ = new Subject<void>();
+    /** Meeting keeps updating as proposals are added; returned to the caller on close. */
+    private latestMeeting: any = null;
+
+    constructor(
+        public dialogRef: MatDialogRef<AddProposalDialogComponent, any>,
+        @Inject(MAT_DIALOG_DATA) public data: AddProposalDialogData,
+        private meetingService: MeetingService,
+        private proposalService: ProposalService,
+        private snackBar: MatSnackBar,
+        private _cdr: ChangeDetectorRef
+    ) {
+        this.year = data?.year || new Date().getFullYear();
+        for (const id of data?.existingProposalIds || []) {
+            this.existing.add(String(id));
+        }
+    }
+
+    ngOnInit(): void {
+        this._search$
+            .pipe(debounceTime(300), takeUntil(this._destroy$))
+            .subscribe(() => this.search());
+        this.search();
+    }
+
+    onYearChange(): void {
+        this._search$.next();
+    }
+
+    onFilterChange(_value: string): void {
+        this._search$.next();
+    }
+
+    search(): void {
+        if (!this.year) {
+            this.results = [];
+            return;
+        }
+        this.loading = true;
+        this._cdr.markForCheck();
+        this.proposalService
+            .getProps(this.year, 0, 50, this.filter || '', 'createdOn', 'desc')
+            .pipe(takeUntil(this._destroy$))
+            .subscribe({
+                next: (res: any) => {
+                    const items = Array.isArray(res) ? res : res?.items || [];
+                    this.results = items;
+                    this.loading = false;
+                    this._cdr.markForCheck();
+                },
+                error: () => {
+                    this.results = [];
+                    this.loading = false;
+                    this.snackBar.open('Could not load proposals', 'Close', { duration: 5000 });
+                    this._cdr.markForCheck();
+                },
+            });
+    }
+
+    proposalId(p: any): string {
+        return String(p?._id ?? '');
+    }
+
+    isOnMeeting(p: any): boolean {
+        return this.existing.has(this.proposalId(p));
+    }
+
+    orgLabel(p: any): string {
+        const o = p?.organization;
+        if (!o || typeof o !== 'object') {
+            return 'Unknown organization';
+        }
+        const name = o.name ? String(o.name).trim() : '';
+        const shortId = o.organizationID ? String(o.organizationID).trim() : '';
+        if (name && shortId) {
+            return `${name} · ${shortId}`;
+        }
+        return name || (shortId ? `Organization ${shortId}` : 'Unknown organization');
+    }
+
+    add(p: any): void {
+        const proposalId = this.proposalId(p);
+        if (!proposalId || this.addingId) {
+            return;
+        }
+        this.addingId = proposalId;
+        this._cdr.markForCheck();
+        this.meetingService
+            .addProposalToMeeting(this.data.meetingId, proposalId)
+            .pipe(takeUntil(this._destroy$))
+            .subscribe({
+                next: (meeting) => {
+                    this.latestMeeting = meeting;
+                    this.existing.add(proposalId);
+                    this.addingId = null;
+                    this.snackBar.open('Proposal added to meeting', 'Close', { duration: 3000 });
+                    this._cdr.markForCheck();
+                },
+                error: (err) => {
+                    this.addingId = null;
+                    const msg = err?.error?.message || 'Could not add proposal to meeting';
+                    this.snackBar.open(msg, 'Close', { duration: 5000 });
+                    this._cdr.markForCheck();
+                },
+            });
+    }
+
+    close(): void {
+        if (this.addingId) {
+            return;
+        }
+        this._destroy$.next();
+        this._destroy$.complete();
+        this.dialogRef.close(this.latestMeeting);
+    }
+}

--- a/src/app/modules/pages/director/meeting-detail/meeting-detail.component.html
+++ b/src/app/modules/pages/director/meeting-detail/meeting-detail.component.html
@@ -35,6 +35,14 @@
                     </span>
                 </div>
                 <div class="flex flex-wrap items-center gap-2">
+                    <button *ngIf="isPresidentOrAdmin"
+                            mat-stroked-button
+                            type="button"
+                            matTooltip="Add a specific proposal to this meeting (including one from another year)"
+                            (click)="openAddProposalDialog()">
+                        <mat-icon class="mr-1">playlist_add</mat-icon>
+                        Add proposal
+                    </button>
                     <span *ngIf="meeting.status === 'completed' && hasFundedProposals() && grantEmailsSentCount !== null"
                           class="inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-full text-xs font-medium"
                           [ngClass]="hasSentGrantEmails

--- a/src/app/modules/pages/director/meeting-detail/meeting-detail.component.ts
+++ b/src/app/modules/pages/director/meeting-detail/meeting-detail.component.ts
@@ -25,6 +25,7 @@ import { AuthService } from 'app/core/auth/auth.service';
 import { UserPreferencesService } from 'app/core/services/user/user-preferences.service';
 import { meetingStatusLabel } from '../meeting-status.labels';
 import { ConfirmDialogComponent } from 'app/common/components/confirm-dialog/confirm-dialog.component';
+import { AddProposalDialogComponent } from './add-proposal-dialog.component';
 
 @Component({
     standalone: false,
@@ -1045,6 +1046,41 @@ export class MeetingDetailComponent implements OnInit, AfterViewInit {
                 this._changeDetectorRef.markForCheck();
             }
         });
+    }
+
+    /**
+     * Open the "add a proposal" dialog so a president/admin can hand-pick a proposal
+     * (including one from another year) into this meeting. Applies the updated meeting
+     * returned by the dialog once it closes.
+     */
+    openAddProposalDialog(): void {
+        if (!this.meeting || !this.isPresidentOrAdmin) {
+            return;
+        }
+        const existingProposalIds = (this.meeting.allocations || [])
+            .map((a: any) => String(a?.proposal?._id ?? a?.proposal ?? ''))
+            .filter(Boolean);
+
+        this.dialog
+            .open(AddProposalDialogComponent, {
+                width: '36rem',
+                maxWidth: '95vw',
+                data: {
+                    meetingId: this.meeting._id,
+                    year: this.meeting.year,
+                    existingProposalIds,
+                },
+            })
+            .afterClosed()
+            .subscribe((updatedMeeting) => {
+                if (updatedMeeting) {
+                    this.applyMeetingResponse(updatedMeeting);
+                    if (updatedMeeting.status === 'completed') {
+                        this.loadSummary(updatedMeeting._id);
+                    }
+                    this._changeDetectorRef.markForCheck();
+                }
+            });
     }
 
     startingMeeting = false;


### PR DESCRIPTION
## Summary
- **THFF-155:** Adds an **Add proposal** button (president/admin only) to the meeting detail header, opening a dialog to search proposals by **title, organization, sponsor, or proposal ID** within a chosen year (defaults to the meeting year, changeable to add an out-of-cycle proposal) and add one to the meeting. Adds go through the new `POST /meeting/:id/allocation` endpoint, are idempotent, and the meeting refreshes live. New `AddProposalDialogComponent` + `MeetingService.addProposalToMeeting`.
- **Bug fix (bundled, separate commit):** the auth interceptor treated any URL containing `/submission-year` as public and stripped the `Authorization` header, so `PUT /submission-year/toggle` (close portal) returned 401. Now only **GET** submission-year requests are treated as public.
- Bumps version to 5.6.15.

Pairs with **thff-be PR #334** (new endpoint + broadened proposal search). Both target `develop` and should be merged together.

## Test plan
- [ ] As president/admin, open a meeting → **Add proposal** → search by title/org/sponsor/ID → **Add** adds the proposal to the meeting live.
- [ ] Change the year in the dialog to add a proposal from another cycle.
- [ ] Proposals already on the meeting show "On meeting" (no duplicate).
- [ ] As a regular director (level 2), the Add proposal button is hidden.
- [ ] Close the submission-year portal as admin (`PUT /submission-year/toggle`) succeeds (no 401); public GET submission-year still works signed-out.

Made with [Cursor](https://cursor.com)