### PR TITLE
fix(submission-years): no table reload on portal toggle (5.6.16)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thff-fuse2",
-  "version": "5.6.15",
+  "version": "5.6.16",
   "description": "THFF FE built with Fuse - Angular Admin Template and Starter Project",
   "author": "lcborn4@gmail.com",
   "license": "https://themeforest.net/licenses/standard",

--- a/src/app/modules/pages/director/submission-years/submission-years.component.ts
+++ b/src/app/modules/pages/director/submission-years/submission-years.component.ts
@@ -62,7 +62,7 @@ export class SubmissionYearsComponent implements OnInit {
             dialogRef.afterClosed().subscribe((confirmed) => {
                 if (confirmed) {
                     this.submissionYearsService.toggleSubmissionYear(yearFound._id, false).subscribe({
-                        next: () => { this.loadSubmissionYears(); },
+                        next: (updated) => { this.applyToggleResult(updated, yearFound._id, false); },
                         error: (err) => {
                             console.error('toggleSubmissionYear error', err);
                             this._snackBar.open('Could not close the portal', 'Close', { duration: 5000 });
@@ -72,13 +72,32 @@ export class SubmissionYearsComponent implements OnInit {
             });
         } else {
             this.submissionYearsService.toggleSubmissionYear(yearFound._id, true).subscribe({
-                next: () => { this.loadSubmissionYears(); },
+                next: (updated) => { this.applyToggleResult(updated, yearFound._id, true); },
                 error: (err) => {
                     console.error('toggleSubmissionYear error', err);
                     this._snackBar.open('Could not open the portal', 'Close', { duration: 5000 });
                 }
             });
         }
+    }
+
+    /** Update the toggled row in place (no full table reload / loading flash). */
+    private applyToggleResult(updated: any, fallbackId: string, active: boolean): void {
+        const id = String(updated?._id ?? fallbackId);
+        const idx = this.years.findIndex((y) => String(y._id) === id);
+        if (idx !== -1) {
+            this.years[idx] = {
+                ...this.years[idx],
+                ...(updated || {}),
+                active: updated?.active ?? active,
+            };
+        }
+        this.dataSource.data = [...this.years];
+        if (this._sort) {
+            this.dataSource.sort = this._sort;
+        }
+        this.checkCurrentYearSubmissionYear();
+        this._cdr.markForCheck();
     }
 
     createSubmissionYear(): void {


### PR DESCRIPTION
## Summary
- Closing/opening the submission-year portal no longer reloads the whole table. It previously called `loadSubmissionYears()`, which flipped the loading state and refetched the list (visible table flash).
- The toggle endpoint already returns the updated record, so we now patch that row in place and reassign `dataSource.data` (preserving sort) with no reload. On error, the table is left untouched and a snackbar is shown.
- Bumps version to 5.6.16.

## Test plan
- [ ] Close the portal for a year → the row's active/toggle state updates instantly with no loading spinner/flash.
- [ ] Open the portal again → same, in place.
- [ ] Sort order is preserved after toggling.
- [ ] On a failed toggle, the row stays unchanged and an error snackbar appears.

Made with [Cursor](https://cursor.com)