### PR TITLE
Release to production: Dependabot fixes (THFF-157, 5.6.17)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thff-fuse2",
-  "version": "5.6.14",
+  "version": "5.6.17",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "thff-fuse2",
-      "version": "5.6.14",
+      "version": "5.6.17",
       "hasInstallScript": true,
       "license": "https://themeforest.net/licenses/standard",
       "dependencies": {
@@ -78,7 +78,7 @@
         "karma-jasmine": "4.0.1",
         "karma-jasmine-html-reporter": "1.7.0",
         "lodash": "^4.18.1",
-        "postcss": "^8.5.8",
+        "postcss": "^8.5.18",
         "tailwind3": "npm:tailwindcss@^3.4.17",
         "tailwindcss": "^4.2.2"
       },
@@ -6236,27 +6236,6 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/@npmcli/package-json/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@npmcli/package-json/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
     "node_modules/@npmcli/package-json/node_modules/glob": {
       "version": "13.0.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
@@ -7976,27 +7955,6 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/@tufjs/models/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@tufjs/models/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
     "node_modules/@tufjs/models/node_modules/minimatch": {
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
@@ -9156,9 +9114,13 @@
       }
     },
     "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -9325,13 +9287,15 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -9462,27 +9426,6 @@
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/cacache/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/cacache/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/cacache/node_modules/glob": {
@@ -9918,11 +9861,6 @@
         }
       ],
       "license": "MIT"
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "node_modules/connect": {
       "version": "3.7.0",
@@ -12380,27 +12318,6 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/ignore-walk/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/ignore-walk/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
     "node_modules/ignore-walk/node_modules/minimatch": {
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
@@ -14767,9 +14684,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -15780,9 +15697,9 @@
       "license": "0BSD"
     },
     "node_modules/postcss": {
-      "version": "8.5.12",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
-      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "version": "8.5.24",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.24.tgz",
+      "integrity": "sha512-8RyVklq0owXUTa4xlpzu4l9AaVKIdQvAcOHZWaMh98HgySsUtxRVf/chRe3dsSLqb6i40BzGRzEUddRaI+9TSw==",
       "dev": true,
       "funding": [
         {
@@ -15800,7 +15717,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -17949,9 +17866,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.19",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.19.tgz",
-      "integrity": "sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -19447,7 +19364,7 @@
         "ora": "9.3.0",
         "picomatch": "4.0.4",
         "piscina": "5.2.0",
-        "postcss": "8.5.12",
+        "postcss": "^8.5.18",
         "postcss-loader": "8.2.0",
         "resolve-url-loader": "5.0.0",
         "rxjs": "7.8.2",
@@ -22734,19 +22651,6 @@
         "spdx-expression-parse": "^4.0.0"
       },
       "dependencies": {
-        "balanced-match": {
-          "version": "4.0.4",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-          "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="
-        },
-        "brace-expansion": {
-          "version": "5.0.7",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-          "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
-          "requires": {
-            "balanced-match": "^4.0.2"
-          }
-        },
         "glob": {
           "version": "13.0.6",
           "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
@@ -22767,7 +22671,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
           "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
           "requires": {
-            "brace-expansion": "^5.0.5"
+            "brace-expansion": "^5.0.8"
           }
         }
       }
@@ -23706,7 +23610,7 @@
         "@alloc/quick-lru": "^5.2.0",
         "@tailwindcss/node": "4.2.2",
         "@tailwindcss/oxide": "4.2.2",
-        "postcss": "^8.5.6",
+        "postcss": "^8.5.18",
         "tailwindcss": "4.2.2"
       }
     },
@@ -23736,25 +23640,12 @@
         "minimatch": "^10.1.1"
       },
       "dependencies": {
-        "balanced-match": {
-          "version": "4.0.4",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-          "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="
-        },
-        "brace-expansion": {
-          "version": "5.0.7",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-          "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
-          "requires": {
-            "balanced-match": "^4.0.2"
-          }
-        },
         "minimatch": {
           "version": "10.2.5",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
           "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
           "requires": {
-            "brace-expansion": "^5.0.5"
+            "brace-expansion": "^5.0.8"
           }
         }
       }
@@ -24616,9 +24507,9 @@
       }
     },
     "balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="
     },
     "base64-js": {
       "version": "1.5.1",
@@ -24654,7 +24545,7 @@
         "domhandler": "^5.0.3",
         "htmlparser2": "^10.0.0",
         "picocolors": "^1.1.1",
-        "postcss": "^8.4.49",
+        "postcss": "^8.5.18",
         "postcss-media-query-parser": "^0.2.3",
         "postcss-safe-parser": "^7.0.1"
       }
@@ -24740,12 +24631,11 @@
       "dev": true
     },
     "brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "requires": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^4.0.2"
       }
     },
     "braces": {
@@ -24821,19 +24711,6 @@
         "ssri": "^13.0.0"
       },
       "dependencies": {
-        "balanced-match": {
-          "version": "4.0.4",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-          "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="
-        },
-        "brace-expansion": {
-          "version": "5.0.7",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-          "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
-          "requires": {
-            "balanced-match": "^4.0.2"
-          }
-        },
         "glob": {
           "version": "13.0.6",
           "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
@@ -24849,7 +24726,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
           "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
           "requires": {
-            "brace-expansion": "^5.0.5"
+            "brace-expansion": "^5.0.8"
           }
         }
       }
@@ -25111,11 +24988,6 @@
         }
       }
     },
-    "concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-    },
     "connect": {
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/connect/-/connect-3.7.0.tgz",
@@ -25289,7 +25161,7 @@
       "dev": true,
       "requires": {
         "icss-utils": "^5.1.0",
-        "postcss": "^8.4.40",
+        "postcss": "^8.5.18",
         "postcss-modules-extract-imports": "^3.1.0",
         "postcss-modules-local-by-default": "^4.0.5",
         "postcss-modules-scope": "^3.2.0",
@@ -26812,25 +26684,12 @@
         "minimatch": "^10.0.3"
       },
       "dependencies": {
-        "balanced-match": {
-          "version": "4.0.4",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-          "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="
-        },
-        "brace-expansion": {
-          "version": "5.0.7",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-          "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
-          "requires": {
-            "balanced-match": "^4.0.2"
-          }
-        },
         "minimatch": {
           "version": "10.2.5",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
           "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
           "requires": {
-            "brace-expansion": "^5.0.5"
+            "brace-expansion": "^5.0.8"
           }
         }
       }
@@ -28118,7 +27977,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^5.0.8"
       }
     },
     "minimist": {
@@ -28308,9 +28167,9 @@
       }
     },
     "nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true
     },
     "natural-compare": {
@@ -28401,7 +28260,7 @@
         "nopt": "^9.0.0",
         "proc-log": "^6.0.0",
         "semver": "^7.3.5",
-        "tar": "^7.5.4",
+        "tar": "^7.5.21",
         "tinyglobby": "^0.2.12",
         "undici": "^7.28.0",
         "which": "^6.0.0"
@@ -28729,7 +28588,7 @@
         "proc-log": "^6.0.0",
         "sigstore": "^4.0.0",
         "ssri": "^13.0.0",
-        "tar": "^7.4.3"
+        "tar": "^7.5.21"
       }
     },
     "parchment": {
@@ -28977,12 +28836,12 @@
       }
     },
     "postcss": {
-      "version": "8.5.12",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
-      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "version": "8.5.24",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.24.tgz",
+      "integrity": "sha512-8RyVklq0owXUTa4xlpzu4l9AaVKIdQvAcOHZWaMh98HgySsUtxRVf/chRe3dsSLqb6i40BzGRzEUddRaI+9TSw==",
       "dev": true,
       "requires": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       }
@@ -29429,7 +29288,7 @@
         "adjust-sourcemap-loader": "^4.0.0",
         "convert-source-map": "^1.7.0",
         "loader-utils": "^2.0.0",
-        "postcss": "^8.2.14",
+        "postcss": "^8.5.18",
         "source-map": "0.6.1"
       },
       "dependencies": {
@@ -30352,7 +30211,7 @@
         "normalize-path": "^3.0.0",
         "object-hash": "^3.0.0",
         "picocolors": "^1.1.1",
-        "postcss": "^8.4.47",
+        "postcss": "^8.5.18",
         "postcss-import": "^15.1.0",
         "postcss-js": "^4.0.1",
         "postcss-load-config": "^4.0.2",
@@ -30392,9 +30251,9 @@
       "dev": true
     },
     "tar": {
-      "version": "7.5.19",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.19.tgz",
-      "integrity": "sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "requires": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",
@@ -30763,7 +30622,7 @@
         "fdir": "^6.5.0",
         "fsevents": "~2.3.3",
         "picomatch": "^4.0.3",
-        "postcss": "^8.5.6",
+        "postcss": "^8.5.18",
         "rollup": "^4.43.0",
         "tinyglobby": "^0.2.15"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thff-fuse2",
-  "version": "5.6.16",
+  "version": "5.6.17",
   "description": "THFF FE built with Fuse - Angular Admin Template and Starter Project",
   "author": "lcborn4@gmail.com",
   "license": "https://themeforest.net/licenses/standard",
@@ -85,7 +85,7 @@
     "karma-jasmine": "4.0.1",
     "karma-jasmine-html-reporter": "1.7.0",
     "lodash": "^4.18.1",
-    "postcss": "^8.5.8",
+    "postcss": "^8.5.18",
     "tailwind3": "npm:tailwindcss@^3.4.17",
     "tailwindcss": "^4.2.2"
   },
@@ -95,6 +95,9 @@
   },
   "overrides": {
     "@babel/core": "^7.29.6",
+    "brace-expansion": "^5.0.8",
+    "tar": "^7.5.21",
+    "postcss": "^8.5.18",
     "hono": "^4.12.25",
     "undici": "^7.28.0",
     "http-proxy-middleware": "^3.0.7",


### PR DESCRIPTION
Promote `staging` -> `master` (production release 5.6.17).

THFF-157 Dependabot security fixes:
- postcss ^8.5.18 + override (GHSA-r28c-9q8g-f849, path traversal)
- brace-expansion override ^5.0.8 (GHSA-mh99-v99m-4gvg, unbounded expansion DoS)
- tar override ^7.5.21 (GHSA-r292-9mhp-454m, recursion DoS)

npm audit: 0 vulnerabilities; production build verified. Clears all 3 open Dependabot alerts on the default branch once merged.

Made with [Cursor](https://cursor.com)